### PR TITLE
Bug fixes

### DIFF
--- a/Sources/CartToolCore/XcodeProj.swift
+++ b/Sources/CartToolCore/XcodeProj.swift
@@ -89,22 +89,17 @@ internal func getDependencies(appPath: Path) throws -> Set<Path> {
     return Set(dependencies.map { $0.removeLastPathComponent() })
 }
 
-private func otool(path: Path) -> Set<String> {
-    do {
-        let output = try shellOutput("otool", "-L", path.absolute)
-        let frameworks = output.components(separatedBy: .newlines)
-            .filter { !$0.isEmpty }
-            .map { $0.components(separatedBy: "(").first! }
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { $0.hasPrefix("@rpath") }
-            .filter { !$0.contains("libswift") }
-            .map { $0.replacingOccurrences(of: "@rpath/", with: "") }
-        
-        return Set(frameworks)
-    } catch {
-        print("Failed to get otool output from \(path)")
-        return []
-    }
+private func otool(path: Path) throws -> Set<String> {
+    let output = try shellOutput("otool", "-L", path.absolute)
+    let frameworks = output.components(separatedBy: .newlines)
+        .filter { !$0.isEmpty }
+        .map { $0.components(separatedBy: "(").first! }
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { $0.hasPrefix("@rpath") }
+        .filter { !$0.contains("libswift") }
+        .map { $0.replacingOccurrences(of: "@rpath/", with: "") }
+    
+    return Set(frameworks)
 }
 
 private func frameworkNames(from paths: [Path]) -> [String] {

--- a/Sources/CartToolCore/XcodeProj.swift
+++ b/Sources/CartToolCore/XcodeProj.swift
@@ -22,10 +22,8 @@ func wrapCarthageCopyFrameworks() throws {
     
     let builtProductsDir = try getEnv("BUILT_PRODUCTS_DIR")
     let frameworksFolderPath = try getEnv("FRAMEWORKS_FOLDER_PATH")
-    let executableName = try getEnv("EXECUTABLE_NAME")
-    let appPath = Path(builtProductsDir)
-        .pathByAppending(component: "\(executableName).app")
-        .pathByAppending(component: executableName)
+    let executablePath = try getEnv("EXECUTABLE_PATH")
+    let appPath = Path(builtProductsDir).pathByAppending(component: executablePath)
     let frameworksTargetDir = Path(builtProductsDir).pathByAppending(component: frameworksFolderPath)
     
     let inputs = try getDependencies(appPath: appPath)


### PR DESCRIPTION
- Use the EXECUTABLE_PATH env variable instead of manually constructing the path. This fixes an issue when the target being built is a WatchKit Extension.

- Allow otool errors to be thrown. Swallowing the errors concealed the issue above because the shell completed successfully even though there was an error.